### PR TITLE
add ref to div 'preview' to support highlight.js

### DIFF
--- a/src/ReactMde.tsx
+++ b/src/ReactMde.tsx
@@ -24,6 +24,7 @@ export class ReactMde extends React.Component<ReactMdeProps> {
 
     converter: Showdown.Converter;
     textArea: HTMLTextAreaElement;
+    preview: HTMLDivElement;
 
     constructor() {
         super();
@@ -115,7 +116,10 @@ export class ReactMde extends React.Component<ReactMdeProps> {
                         {...textAreaProps}
                     />
                 </div>
-                <div className="mde-preview" dangerouslySetInnerHTML={{__html: html}}/>
+                <div className="mde-preview" dangerouslySetInnerHTML={{__html: html}}
+                     ref={(p) => {
+                            this.preview = p;
+                        }} />
                 <div className="mde-help">
                     <MarkdownHelp/>
                 </div>


### PR DESCRIPTION
my test code:

```js
  handleValueChange(value) {
        console.log(value);
        this.setState({mdeValue:value});
        let event = {};
        event.target = {};
        event.target.value =value.text;
        this.props.onChange(event);

        this._TeX(value.text);    // when text change, render to highlight.

    }
    
    _TeX(html) {
        if (window.katex) {
            if (html) {
                this.mde_editor.innerHTML = html;
            }
            let codeTags = this.mde_editor.refs.preview.getElementsByTagName('code') ;
            let hljs = require('highlight.js');
            for (let i in codeTags) {
                let code = codeTags[i];
                if (code.innerText) {
                    hljs.highlightBlock(code);
                }
            }
        }
    }

    render() {
        // get the default commands, you can pick individual commands if you like, or add your own
        let commands = ReactMdeCommands.getDefaultCommands();

        return (
            <div className="content"   >

                <ReactMde
                    textareaId="ta1"
                    textareaName="ta1"
                    value={this.state.mdeValue}
                    onChange={this.handleValueChange}
                    ref={e => this.mde_editor = e}
                    commands={commands} />

            </div>
        );
    }
```