### PR TITLE
Allow execute to return Promise<Value> or Value

### DIFF
--- a/src/ReactMde.tsx
+++ b/src/ReactMde.tsx
@@ -37,7 +37,11 @@ export class ReactMde extends React.Component<ReactMdeProps> {
     handleCommand = (command: Command) => {
         const {value: {text}, onChange} = this.props;
         const newValue = command.execute(text, getSelection(this.textArea));
-        onChange(newValue);
+        if (newValue instanceof Promise) {
+            newValue.then((v) => onChange(v));
+        } else {
+            onChange(newValue);
+        }
     }
 
     /**

--- a/src/types/Command.ts
+++ b/src/types/Command.ts
@@ -5,5 +5,5 @@ export interface Command {
     type?: string;
     icon?: string;
     tooltip?: string;
-    execute: (text: string, selection: TextSelection) => Value;
+    execute: (text: string, selection: TextSelection) => Value | Promise<Value>;
 }


### PR DESCRIPTION
This allows to use `async` behavior in the execute function like fetching urls from a server.