### PR TITLE
Include scrollTop and selection in onChange event

### DIFF
--- a/src/ReactMdeTextArea.tsx
+++ b/src/ReactMdeTextArea.tsx
@@ -27,7 +27,14 @@ export class ReactMdeTextArea extends React.Component<ReactMdeTextAreaProps, Rea
      */
     handleValueChange = (e: React.FormEvent<HTMLTextAreaElement>) => {
         const {onChange} = this.props;
-        onChange({text: e.currentTarget.value});
+        onChange({
+            text: e.currentTarget.value,
+            scrollTop: e.currentTarget.scrollTop,
+            selection: { 
+                start: e.currentTarget.selectionStart, 
+                end: e.currentTarget.selectionEnd 
+            }
+        });
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
Changed _handleValueChange_ in _ReactMdeTextArea_ to also include _scrollTop_ and _selection_, thus returning a full _Value_ object.

I required this functionality as I need to be able to persist selections and caret positions.