### PR TITLE
Tooltips for dropdowns

### DIFF
--- a/src/commands/headerCommand.tsx
+++ b/src/commands/headerCommand.tsx
@@ -5,6 +5,7 @@ import React = require("react");
 export const headerCommand: CommandSet = {
     type: "dropdown",
     icon: "heading",
+    tooltip: "Add header",
     subCommands: [
         {
             content: <p className="header-1">Header</p>,

--- a/src/components/HeaderItemDropdown.tsx
+++ b/src/components/HeaderItemDropdown.tsx
@@ -4,6 +4,7 @@ import { SubCommand } from "../types";
 
 export interface HeaderItemDropdownProps {
     icon: React.ReactNode;
+    tooltip?: string;
     commands: SubCommand[];
     onCommand: (command: SubCommand) => void;
 }
@@ -70,7 +71,7 @@ export class HeaderItemDropdown extends React.Component<HeaderItemDropdownProps,
     }
 
     render() {
-        const {icon, commands} = this.props;
+        const {icon, commands, tooltip} = this.props;
         const {open} = this.state;
 
         // if icon is a text, print a font-awesome <i/>, otherwise, consider it a React component and print it
@@ -95,10 +96,19 @@ export class HeaderItemDropdown extends React.Component<HeaderItemDropdownProps,
             )
             : null;
 
+        let buttonProps = {};
+        if (tooltip) {
+            buttonProps = {
+                "aria-label": tooltip,
+                "className": "tooltipped",
+            };
+        }
+
         return (
             <li className="mde-header-item">
                 <button
                     type="button"
+                    {...buttonProps} 
                     ref={(ref) => {
                         this.dropdownOpener = ref;
                     }}

--- a/src/components/ReactMdeToolbar.tsx
+++ b/src/components/ReactMdeToolbar.tsx
@@ -25,6 +25,7 @@ export const ReactMdeToolbar: React.SFC<ReactMdeToolbarProps> = ({commands, onCo
                                         <HeaderItemDropdown
                                             key={j}
                                             icon={c.icon}
+                                            tooltip={c.tooltip}
                                             commands={(c as CommandSet).subCommands}
                                             onCommand={(cmd) => onCommand(cmd)}
                                         />

--- a/src/types/CommandSet.ts
+++ b/src/types/CommandSet.ts
@@ -2,7 +2,7 @@ import { SubCommand } from "./SubCommand";
 
 export interface CommandSet {
     type?: string;
-    icon?: string;
+    icon?: React.ReactNode;
     tooltip?: string;
     subCommands?: SubCommand[];
 }


### PR DESCRIPTION
Dropdown commands can now (optionally) use tooltips(e.g. the header dropdown).
Also changed the data type of _icon_ in _CommandSet_ to _ReactNode_.