### PR TITLE
IMPORTANT: Fix for updating Webpack to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "css-loader": "^0.28.10",
     "draft-js": "^0.10.5",
     "express": "^4.16.2",
-    "extract-text-webpack-plugin": "^3.0.2",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.9",
     "gulp": "^3.9.1",
     "gulp-cli": "^2.0.1",

--- a/webpack.config.demo.dev.js
+++ b/webpack.config.demo.dev.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 
 module.exports = {
+    mode: "development",
 
     entry: [
         './demo/client.tsx'

--- a/webpack.config.demo.prod.js
+++ b/webpack.config.demo.prod.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
+    mode: "production",
 
     entry: [
         './demo/client.tsx'


### PR DESCRIPTION
You're updated Webpack to v4, but you should make these changes to correct working:
- Webpack v4 require mode parameter — development or production
- Extract-text-webpack-plugin v3 don't work with Webpack v4 — one need to use v4 beta