### PR TITLE
Fully specify the scss files

### DIFF
--- a/src/styles/react-mde-all.scss
+++ b/src/styles/react-mde-all.scss
@@ -1,8 +1,8 @@
-@import "react-mde-toolbar";
-@import "react-mde-editor";
-@import "react-mde-preview";
-@import "react-mde";
-@import "react-mde-vertical-layout";
-@import "react-mde-no-preview-layout";
-@import "react-mde-horizontal-layout";
-@import "react-mde-tabbed-layout";
+@import "react-mde-toolbar.scss";
+@import "react-mde-editor.scss";
+@import "react-mde-preview.scss";
+@import "react-mde.scss";
+@import "react-mde-vertical-layout.scss";
+@import "react-mde-no-preview-layout.scss";
+@import "react-mde-horizontal-layout.scss";
+@import "react-mde-tabbed-layout.scss";

--- a/src/styles/react-mde-editor.scss
+++ b/src/styles/react-mde-editor.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .mde-text {
 

--- a/src/styles/react-mde-horizontal-layout.scss
+++ b/src/styles/react-mde-horizontal-layout.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .react-mde-horizontal-layout {
     height: 100%;

--- a/src/styles/react-mde-no-preview-layout.scss
+++ b/src/styles/react-mde-no-preview-layout.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .react-mde-no-preview-layout {
   height: 100%;

--- a/src/styles/react-mde-preview.scss
+++ b/src/styles/react-mde-preview.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .mde-preview {
   min-height: $mde-preview-default-min-height;

--- a/src/styles/react-mde-tabbed-layout.scss
+++ b/src/styles/react-mde-tabbed-layout.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .react-mde-tabbed-layout {
     height: 100%;

--- a/src/styles/react-mde-toolbar.scss
+++ b/src/styles/react-mde-toolbar.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .mde-header {
   flex-shrink: 0;

--- a/src/styles/react-mde-vertical-layout.scss
+++ b/src/styles/react-mde-vertical-layout.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 .react-mde-vertical-layout {
     display: flex;

--- a/src/styles/react-mde.scss
+++ b/src/styles/react-mde.scss
@@ -1,4 +1,4 @@
-@import "variables";
+@import "variables.scss";
 
 * {
     box-sizing: border-box;


### PR DESCRIPTION
In cases where css files are created in place from the scss files during a build process it can be problematic to loosely specify the import path, as both the .scss and .css files both match on a second run.

```
node-sass-chokidar src/ -o src/

{
  "status": 1,
  "file": "/Users/craighills/code/agave/node_modules/react-mde/lib/styles/scss/react-mde-all.scss",
  "line": 1,
  "column": 1,
  "message": "It's not clear which file to import for '@import \"variables\"'.\nCandidates:\n  variables.scss\n  variables.css\nPlease delete or rename all but one of these files.\n",
  "formatted": "Error: It's not clear which file to import for '@import \"variables\"'.\n       Candidates:\n         variables.scss\n         variables.css\n       Please delete or rename all but one of these files.\n        on line 1 of node_modules/react-mde/lib/styles/scss/react-mde-all.scss\n>> @import \"variables\";\n   ^\n"
}
```

We can avoid this issue by fully specifying the .scss file in the import.