### PR TITLE
Fixes insert-text-at-cursor import

### DIFF
--- a/src/commandOrchestrator.ts
+++ b/src/commandOrchestrator.ts
@@ -1,6 +1,6 @@
 import { Command, TextRange } from "./types";
 import { TextApi, TextState } from "./types/CommandOptions";
-import insertText from "insert-text-at-cursor";
+import insertText = require("insert-text-at-cursor");
 
 export interface CommandOrchestrator {
   executeCommand (command: Command): void

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,3 +1,4 @@
 declare module "insert-text-at-cursor" {
-    export default function(input: HTMLTextAreaElement, text: string): void;
+    function insertText(input: HTMLTextAreaElement, text: string): void;
+    export = insertText;
 }


### PR DESCRIPTION
**Problem:**

`insert_text_at_cursor_1.default is not a Function` error occurs after using command buttons.

**Explanation:**

insert-text-at-cursor module has following simplified structure
```
node_modules/insert-text-at-cursor
├── dist
│   └── index.umd.js
├── index.js
└── package.json (has "main" field containing  "dist/index.umd.js")
```
Typescript compiles react-mde project, using `node_modules/insert-text-at-cursor/index.js` module and produces code that calls `insertText.default`
```
insert_text_at_cursor_1.default(this.textArea, text);
```
Trying to import and use react-mde in javascript project fails, cause webpack loads `node_modules/insert-text-at-cursor/dist/index.umd.js` that has no default export.

