### PR TITLE
Fix ARIA labels in code, link, and quote commands

### DIFF
--- a/src/commands/codeCommand.tsx
+++ b/src/commands/codeCommand.tsx
@@ -5,7 +5,7 @@ import {getBreaksNeededForEmptyLineAfter, getBreaksNeededForEmptyLineBefore, sel
 
 export const codeCommand: Command = {
     name: "code",
-    buttonProps: {"aria-label": "Add bold text"},
+    buttonProps: {"aria-label": "Insert code"},
     execute: (state0: TextState, api: TextApi) => {
         // Adjust the selection to encompass the whole word if the caret is inside one
         const newSelectionRange = selectWord({text: state0.text, selection: state0.selection});

--- a/src/commands/linkCommand.tsx
+++ b/src/commands/linkCommand.tsx
@@ -5,7 +5,7 @@ import {selectWord} from "../util/MarkdownUtil";
 
 export const linkCommand: Command = {
     name: "link",
-    buttonProps: {"aria-label": "Add bold text"},
+    buttonProps: {"aria-label": "Add a link"},
     execute: (state0: TextState, api: TextApi) => {
         // Adjust the selection to encompass the whole word if the caret is inside one
         const newSelectionRange = selectWord({text: state0.text, selection: state0.selection});

--- a/src/commands/quoteCommand.tsx
+++ b/src/commands/quoteCommand.tsx
@@ -5,7 +5,7 @@ import {getBreaksNeededForEmptyLineAfter, getBreaksNeededForEmptyLineBefore, sel
 
 export const quoteCommand: Command = {
     name: "quote",
-    buttonProps: { "aria-label": "Add bold text" },
+    buttonProps: { "aria-label": "Insert a quote" },
     execute: (state0: TextState, api: TextApi) => {
         // Adjust the selection to encompass the whole word if the caret is inside one
         const newSelectionRange = selectWord({ text: state0.text, selection: state0.selection });


### PR DESCRIPTION
Just a small fix: the ARIA label was still `Add bold text` for a few commands. This PR introduces new labels for those commands, based on the tooltips that GitHub uses in its own editor:

<img width="523" alt="Screen Shot 2019-07-05 at 16 41 55" src="https://user-images.githubusercontent.com/352105/60731174-2beda600-9f47-11e9-8871-c358d36222d5.png">

<img width="515" alt="Screen Shot 2019-07-05 at 16 42 00" src="https://user-images.githubusercontent.com/352105/60731175-2c863c80-9f47-11e9-9927-2dd92f1200d2.png">

<img width="525" alt="Screen Shot 2019-07-05 at 16 41 49" src="https://user-images.githubusercontent.com/352105/60731173-2beda600-9f47-11e9-97e7-c5dc659c8368.png">
