### PR TITLE
fix changing the value while in preview mode

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -76,6 +76,7 @@ export class App extends React.Component<{}, AppState> {
             suggestionsDropdown: "bbbb"
           }}
         />
+        value: <input type="text" value={this.state.value} onChange={(e) => {this.handleValueChange(e.target.value) }}/>
       </div>
     );
   }

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -39,6 +39,17 @@ export class Preview extends React.Component<
     });
   }
 
+  componentWillReceiveProps(nextProps): void {
+    if(nextProps.markdown !== this.props.markdown) {
+      nextProps.generateMarkdownPreview(nextProps.markdown).then(preview => {
+        this.setState({
+          preview,
+          loading: false
+        });
+      });
+    }
+  }
+
   render() {
     const { classes, minHeight, loadingPreview } = this.props;
     const { preview, loading } = this.state;


### PR DESCRIPTION
Currently there is a bug when changing the `value` attribute while staying always in preview mode, without switching to edit mode - nothing happens. 
The markdown doesn't get updated. 
This is a simple fix for such case.