### PR TITLE
feat: implement highlighting support

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -8,13 +8,43 @@ export interface AppState {
   tab: "write" | "preview";
 }
 
+const findIndicies = (source: string, needle: string): number[]  => {
+  if (!source) {
+    return [];
+  }
+  // if find is empty string return all indexes.
+  if (!needle) {
+    // or shorter arrow function:
+    // return source.split('').map((_,i) => i);
+    return source.split('').map(function(_, i) { return i; });
+  }
+  var result = [];
+  for (let i = 0; i < source.length; ++i) {
+    // If you want to search case insensitive use 
+    // if (source.substring(i, i + find.length).toLowerCase() == find) {
+    if (source.substring(i, i + needle.length) == needle) {
+      result.push(i);
+    }
+  }
+  return result;
+}
+
+const text = `
+**Lorem** ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt 
+ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo 
+duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+`
+
 export class App extends React.Component<{}, AppState> {
   converter: Showdown.Converter;
 
   constructor(props) {
     super(props);
     this.state = {
-      value: "**Hello world!!!**",
+      value: text,
       tab: "write"
     };
     this.converter = new Showdown.Converter({
@@ -74,6 +104,12 @@ export class App extends React.Component<{}, AppState> {
           suggestionTriggerCharacters={["@"]}
           classes={{
             suggestionsDropdown: "bbbb"
+          }}
+          highlight={(content) => {
+            return findIndicies(content, "Lorem").map(startIndex => ({
+              color: "pink",
+              range: [startIndex, startIndex + "Lorem".length] as [number, number]
+            }))
           }}
         />
         value:{" "}

--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -4,7 +4,8 @@ import {
   CommandGroup,
   GenerateMarkdownPreview,
   GetIcon,
-  Suggestion
+  Suggestion,
+  Highlight,
 } from "../types";
 import { getDefaultCommands } from "../commands";
 import { Preview, Toolbar, TextArea } from ".";
@@ -49,6 +50,7 @@ export interface ReactMdeProps {
    */
   textAreaProps?: TextAreaChildProps;
   l18n?: L18n;
+  highlight?: (text: string) => Highlight[];
 }
 
 export interface ReactMdeState {
@@ -165,13 +167,14 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       disablePreview,
       value,
       l18n,
+      highlight,
       minPreviewHeight,
       childProps,
       textAreaProps,
       selectedTab,
       generateMarkdownPreview,
       loadSuggestions,
-      suggestionTriggerCharacters
+      suggestionTriggerCharacters,
     } = this.props;
 
     const finalChildProps = childProps || {};
@@ -214,6 +217,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
             value={value}
             suggestionTriggerCharacters={suggestionTriggerCharacters}
             loadSuggestions={loadSuggestions}
+            highlight={highlight}
           />
           <div
             className={classNames("grip", classes?.grip)}

--- a/src/styles/react-mde-editor.scss
+++ b/src/styles/react-mde-editor.scss
@@ -2,8 +2,38 @@
 
 .mde-textarea-wrapper {
   position: relative;
+  background-color: #fff;
+  font-size: 18px;
+
+  .mde-highlight-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border: 1px solid transparent;
+
+    .mde-highlights {
+      height: auto;
+      width: auto;
+      color: transparent;
+      padding: 10px;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      overflow: auto;
+
+      .mde-highlight {
+        position: relative;
+        color: inherit;
+        background-color: yellow;
+      }
+    }
+  }
 
   textarea.mde-text {
+    position: relative;
+    background-color: transparent;
     width: 100%;
     border: 0;
     padding: $mde-editor-padding;

--- a/src/types/Highlight.ts
+++ b/src/types/Highlight.ts
@@ -1,0 +1,4 @@
+export interface Highlight {
+  color: string;
+  range: [number, number]
+}

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -6,3 +6,4 @@ export * from "./TextInsertionResult";
 export * from "./TextRange";
 export * from "./TextSection";
 export * from "./Suggestion";
+export * from "./Highlight"


### PR DESCRIPTION
Tested on Safari 12.0.3, Chrome 81 and Firefox 75.

Reference Implementation for https://github.com/andrerpena/react-mde/issues/232 based on https://github.com/lonekorean/highlight-within-textarea

Demo:
![image](https://user-images.githubusercontent.com/14338007/79917381-b34ecc00-842a-11ea-8e57-2f10e292b3b7.png)

____

The implementation is indeed a bit hacky and probably something like [monaco](https://microsoft.github.io/monaco-editor/) is a better fitted for such use-cases, however, I would still like to hear your opinion on this @andrerpena.

My specific use-case involves highlighting a subsection in the textarea while showing a side bar for manipulating the selection. E.g. `<Image src="some-id" />` and selecting a Image. The highlighting should serve as a visual indicator for the user.