### PR TITLE
Allows customizing the textarea component used

### DIFF
--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -48,6 +48,7 @@ export interface ReactMdeProps {
    * "textAreaProps" is OBSOLETE. It will soon be removed in favor of the "defaultChildProps" prop
    */
   textAreaProps?: TextAreaChildProps;
+  textAreaComponent?: React.ReactNode;
   l18n?: L18n;
 }
 
@@ -210,6 +211,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
             onChange={this.handleTextChange}
             readOnly={readOnly}
             textAreaProps={(childProps && childProps.textArea) || textAreaProps}
+            textAreaComponent={this.props.textAreaComponent}
             height={this.state.editorHeight}
             value={value}
             suggestionTriggerCharacters={suggestionTriggerCharacters}

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -47,6 +47,7 @@ export interface TextAreaProps {
       HTMLTextAreaElement
     >
   >;
+  textAreaComponent?: React.ReactNode;
 }
 
 export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
@@ -313,9 +314,10 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
       loadSuggestions;
 
     const { mention } = this.state;
+    const TextAreaComponent: any = this.props.textAreaComponent || "textarea"
     return (
       <div className="mde-textarea-wrapper">
-        <textarea
+        <TextAreaComponent
           className={classNames("mde-text", classes)}
           style={{ height }}
           ref={this.handleTextAreaRef}


### PR DESCRIPTION
Hi!

I'm trying to use your library using [ClojureScript](https://clojurescript.org/) and [Reagent](https://reagent-project.github.io/). I have hit a simple yet annoying problem.

The Reagent library (which is a wrapper around React for cljs) needs to take special care with `textarea` components. It has to do with async rendering and caret positioning, and I won't go into details*. Long story short: for using your library I simply need to be able to use a custom `textarea` component.

I'm aware that this is a quite "specific" need, but it would make the library usable for anyone using reagent and maybe you can even think on other use cases for having a custom textarea component.

I could make it work with this quite simple changes that are in this PR. I wanted to ask you if you would be willing to accept those changes (I can add it to the docs and whatever change you may want).

Thanks!

*if you are curious, see https://github.com/madvas/cljs-react-material-ui/issues/17 and https://github.com/reagent-project/reagent/issues/265#issuecomment-397895508