### PR TITLE
9.0.0

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -79,14 +79,6 @@ export class App extends React.Component<{}, AppState> {
             <textarea ref={ref} {...p} />
           ))}
         />
-        value:{" "}
-        <input
-          type="text"
-          value={this.state.value}
-          onChange={e => {
-            this.handleValueChange(e.target.value);
-          }}
-        />
       </div>
     );
   }

--- a/src/commandOrchestrator.ts
+++ b/src/commandOrchestrator.ts
@@ -1,32 +1,33 @@
-import { Command, TextRange } from "./types";
+import { Command, CommandGroup, TextRange } from "./types";
 import { TextApi, TextState } from "./types/CommandOptions";
 import { insertText } from "./util/InsertTextAtPosition";
-
-export interface CommandOrchestrator {
-  executeCommand(command: Command): void;
-}
+import { extractKeyActivatedCommands } from "./util/CommandUtils";
+import * as React from "react";
 
 export class TextAreaTextApi implements TextApi {
-  textArea: HTMLTextAreaElement;
+  textAreaRef: React.RefObject<HTMLTextAreaElement>;
 
-  constructor(textArea: HTMLTextAreaElement) {
-    this.textArea = textArea;
+  constructor(textAreaRef: React.RefObject<HTMLTextAreaElement>) {
+    this.textAreaRef = textAreaRef;
   }
 
   replaceSelection(text: string): TextState {
-    insertText(this.textArea, text);
-    return getStateFromTextArea(this.textArea);
+    const textArea = this.textAreaRef.current;
+    insertText(textArea, text);
+    return getStateFromTextArea(textArea);
   }
 
   setSelectionRange(selection: TextRange): TextState {
-    this.textArea.focus();
-    this.textArea.selectionStart = selection.start;
-    this.textArea.selectionEnd = selection.end;
-    return getStateFromTextArea(this.textArea);
+    const textArea = this.textAreaRef.current;
+    textArea.focus();
+    textArea.selectionStart = selection.start;
+    textArea.selectionEnd = selection.end;
+    return getStateFromTextArea(textArea);
   }
 
   getState(): TextState {
-    return getStateFromTextArea(this.textArea);
+    const textArea = this.textAreaRef.current;
+    return getStateFromTextArea(textArea);
   }
 }
 
@@ -44,16 +45,56 @@ export function getStateFromTextArea(textArea: HTMLTextAreaElement): TextState {
   };
 }
 
-export class TextAreaCommandOrchestrator implements CommandOrchestrator {
-  textArea: HTMLTextAreaElement;
+export class CommandOrchestrator {
+  textAreaRef: React.RefObject<HTMLTextAreaElement>;
   textApi: TextApi;
+  commands: CommandGroup[];
+  keyActivatedCommands: Command[];
+  /**
+   * Indicates whether there is a command currently executing
+   */
+  isExecuting: boolean;
 
-  constructor(textArea: HTMLTextAreaElement) {
-    this.textArea = textArea;
+  constructor(
+    commands: CommandGroup[],
+    textArea: React.RefObject<HTMLTextAreaElement>
+  ) {
+    this.commands = commands;
+    this.keyActivatedCommands = extractKeyActivatedCommands(commands);
+    this.textAreaRef = textArea;
     this.textApi = new TextAreaTextApi(textArea);
   }
 
-  executeCommand(command: Command): void {
-    command.execute(getStateFromTextArea(this.textArea), this.textApi);
+  /**
+   * Tries to find a command the wants to handle the keyboard event
+   */
+  handlePossibleKeyCommand = (
+    e: React.KeyboardEvent<HTMLTextAreaElement>
+  ): boolean => {
+    for (const command of this.keyActivatedCommands) {
+      if (command.handleKeyCommand(e)) {
+        this.executeCommand(command).then(r => {});
+        return true;
+      }
+    }
+    return false;
+  };
+
+  async executeCommand(command: Command): Promise<void> {
+    if (this.isExecuting) {
+      // The simplest thing to do is to ignore commands while
+      // there is already a command executing. The alternative would be to queue commands
+      // but there is no guarantee that the state after one command executes will still be compatible
+      // with the next one. In fact, it is likely not to be.
+      return;
+    }
+
+    this.isExecuting = true;
+    const result = command.execute(
+      getStateFromTextArea(this.textAreaRef.current),
+      this.textApi
+    );
+    await result;
+    this.isExecuting = false;
   }
 }

--- a/src/commands/boldCommand.tsx
+++ b/src/commands/boldCommand.tsx
@@ -21,5 +21,5 @@ export const boldCommand: Command = {
       end: state2.selection.end - 2
     });
   },
-  keyCommand: "bold"
+  handleKeyCommand: e => (e.ctrlKey || e.metaKey) && e.key == "b"
 };

--- a/src/commands/codeCommand.tsx
+++ b/src/commands/codeCommand.tsx
@@ -56,6 +56,5 @@ export const codeCommand: Command = {
       start: selectionStart,
       end: selectionEnd
     });
-  },
-  keyCommand: "code"
+  }
 };

--- a/src/commands/imageCommand.tsx
+++ b/src/commands/imageCommand.tsx
@@ -22,6 +22,5 @@ export const imageCommand: Command = {
       start: 4 + state1.selection.start,
       end: 4 + state1.selection.start + imageTemplate.length
     });
-  },
-  keyCommand: "image"
+  }
 };

--- a/src/commands/italicCommand.tsx
+++ b/src/commands/italicCommand.tsx
@@ -21,5 +21,5 @@ export const italicCommand: Command = {
       end: state2.selection.end - 1
     });
   },
-  keyCommand: "italic"
+  handleKeyCommand: e => (e.ctrlKey || e.metaKey) && e.key == "i"
 };

--- a/src/commands/linkCommand.tsx
+++ b/src/commands/linkCommand.tsx
@@ -21,5 +21,5 @@ export const linkCommand: Command = {
       end: state2.selection.end - 6
     });
   },
-  keyCommand: "bold"
+  handleKeyCommand: e => (e.ctrlKey || e.metaKey) && e.key == "k"
 };

--- a/src/commands/listCommands.tsx
+++ b/src/commands/listCommands.tsx
@@ -87,8 +87,7 @@ export const unorderedListCommand: Command = {
   buttonProps: { "aria-label": "Add unordered list" },
   execute: (state0: TextState, api: TextApi) => {
     makeList(state0, api, "- ");
-  },
-  keyCommand: "code"
+  }
 };
 
 export const orderedListCommand: Command = {
@@ -96,8 +95,7 @@ export const orderedListCommand: Command = {
   buttonProps: { "aria-label": "Add ordered list" },
   execute: (state0: TextState, api: TextApi) => {
     makeList(state0, api, (item, index) => `${index + 1}. `);
-  },
-  keyCommand: "code"
+  }
 };
 
 export const checkedListCommand: Command = {
@@ -105,6 +103,5 @@ export const checkedListCommand: Command = {
   buttonProps: { "aria-label": "Add checked list" },
   execute: (state0: TextState, api: TextApi) => {
     makeList(state0, api, (item, index) => `- [ ] `);
-  },
-  keyCommand: "code"
+  }
 };

--- a/src/commands/quoteCommand.tsx
+++ b/src/commands/quoteCommand.tsx
@@ -42,6 +42,5 @@ export const quoteCommand: Command = {
       start: selectionStart,
       end: selectionEnd
     });
-  },
-  keyCommand: "quote"
+  }
 };

--- a/src/commands/strikeThroughCommand.tsx
+++ b/src/commands/strikeThroughCommand.tsx
@@ -20,6 +20,5 @@ export const strikeThroughCommand: Command = {
       start: state2.selection.end - 2 - state1.selectedText.length,
       end: state2.selection.end - 2
     });
-  },
-  keyCommand: "strikeThrough"
+  }
 };

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -4,7 +4,7 @@ import { classNames, ClassValue } from "../util/ClassNames";
 
 export interface PreviewProps {
   classes?: ClassValue;
-  previewRef?: (ref: Preview) => void;
+  refObject?: React.RefObject<HTMLDivElement>;
   loadingPreview?: React.ReactNode;
   minHeight: number;
   generateMarkdownPreview: GenerateMarkdownPreview;
@@ -20,8 +20,6 @@ export class Preview extends React.Component<
   PreviewProps,
   ReactMdePreviewState
 > {
-  previewRef: HTMLDivElement;
-
   constructor(props) {
     super(props);
     this.state = {
@@ -51,7 +49,7 @@ export class Preview extends React.Component<
   }
 
   render() {
-    const { classes, minHeight, loadingPreview } = this.props;
+    const { classes, minHeight, loadingPreview, refObject } = this.props;
     const { preview, loading } = this.state;
     const finalHtml = loading ? loadingPreview : preview;
 
@@ -62,7 +60,7 @@ export class Preview extends React.Component<
         <div
           className="mde-preview-content"
           dangerouslySetInnerHTML={{ __html: finalHtml || "<p>&nbsp;</p>" }}
-          ref={p => (this.previewRef = p)}
+          ref={refObject}
         />
       );
     } else {

--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -3,12 +3,10 @@ import {
   Command,
   CommandGroup,
   GenerateMarkdownPreview,
-  GetIcon,
-  Suggestion
+  GetIcon
 } from "../types";
 import { getDefaultCommands } from "../commands";
 import { Preview, Toolbar, TextArea } from ".";
-import { extractCommandMap } from "../util/CommandUtils";
 import { Tab } from "../types/Tab";
 import { Classes, L18n } from "..";
 import { enL18n } from "../l18n/react-mde.en";
@@ -17,8 +15,8 @@ import {
   TextAreaCommandOrchestrator
 } from "../commandOrchestrator";
 import { SvgIcon } from "../icons";
-import { classNames, ClassValue } from "../util/ClassNames";
-import { ChildProps, TextAreaChildProps } from "../child-props";
+import { classNames } from "../util/ClassNames";
+import { ChildProps } from "../child-props";
 
 export interface ReactMdeProps {
   value: string;
@@ -30,24 +28,14 @@ export interface ReactMdeProps {
   maxEditorHeight: number;
   minPreviewHeight: number;
   classes?: Classes;
-  /**
-   * "className" is OBSOLETE. It will soon be removed in favor of the "classes" prop
-   */
-  className?: ClassValue;
   commands?: CommandGroup[];
   getIcon?: GetIcon;
-  // deprecated. Use emptyPreview instead
-  emptyPreviewHtml?: string;
   loadingPreview?: React.ReactNode;
   readOnly?: boolean;
   disablePreview?: boolean;
   suggestionTriggerCharacters?: string[];
   loadSuggestions?: (text: string) => Promise<Suggestion[]>;
   childProps?: ChildProps;
-  /**
-   * "textAreaProps" is OBSOLETE. It will soon be removed in favor of the "defaultChildProps" prop
-   */
-  textAreaProps?: TextAreaChildProps;
   l18n?: L18n;
 }
 
@@ -67,12 +55,9 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
     originalHeight: number;
   } = null;
 
-  keyCommandMap: { [key: string]: Command };
-
   static defaultProps: Partial<ReactMdeProps> = {
     commands: getDefaultCommands(),
     getIcon: name => <SvgIcon icon={name} />,
-    emptyPreviewHtml: "<p>&nbsp;</p>",
     readOnly: false,
     l18n: enL18n,
     minEditorHeight: 200,
@@ -88,9 +73,6 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
     this.state = {
       editorHeight: props.minEditorHeight
     };
-    this.keyCommandMap = {};
-    const { commands } = this.props;
-    this.keyCommandMap = extractCommandMap(commands);
   }
 
   handleTextChange = (value: string) => {
@@ -158,16 +140,13 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       getIcon,
       commands,
       classes,
-      className,
       loadingPreview,
-      emptyPreviewHtml,
       readOnly,
       disablePreview,
       value,
       l18n,
       minPreviewHeight,
       childProps,
-      textAreaProps,
       selectedTab,
       generateMarkdownPreview,
       loadSuggestions,
@@ -181,11 +160,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
         className={classNames(
           "react-mde",
           "react-mde-tabbed-layout",
-          classes?.reactMde,
-          /**
-           * "className" is OBSOLETE and will soon be removed
-           */
-          className
+          classes?.reactMde
         )}
       >
         <Toolbar
@@ -209,7 +184,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
             editorRef={this.setTextAreaRef}
             onChange={this.handleTextChange}
             readOnly={readOnly}
-            textAreaProps={(childProps && childProps.textArea) || textAreaProps}
+            textAreaProps={childProps && childProps.textArea}
             height={this.state.editorHeight}
             value={value}
             suggestionTriggerCharacters={suggestionTriggerCharacters}
@@ -240,7 +215,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
           <Preview
             classes={classes?.preview}
             previewRef={c => (this.previewRef = c)}
-            loadingPreview={loadingPreview || emptyPreviewHtml}
+            loadingPreview={loadingPreview}
             minHeight={minPreviewHeight}
             generateMarkdownPreview={generateMarkdownPreview}
             markdown={value}

--- a/src/refs.ts
+++ b/src/refs.ts
@@ -1,0 +1,6 @@
+import * as React from "react";
+
+export interface Refs {
+  textarea?: React.RefObject<HTMLTextAreaElement>;
+  preview?: React.RefObject<HTMLDivElement>;
+}

--- a/src/types/Command.ts
+++ b/src/types/Command.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { TextApi, TextState } from "./CommandOptions";
+import { HandleKeyCommand } from "./FunctionTypes";
 
 export type GetIcon = (iconName: string) => React.ReactNode;
 
@@ -9,8 +10,11 @@ export interface Command {
   icon?: (getIconFromProvider: GetIcon) => React.ReactNode;
   buttonProps?: any;
   children?: Command[];
-  execute?: (state: TextState, api: TextApi) => void;
-  // Draft.js triggers Key Commands. the keyCommand property determines
-  // which Draft.js key command should be handled by this react-mde command
-  keyCommand?: string;
+  execute?: (state: TextState, api: TextApi) => void | Promise<void>;
+  /**
+   * On every key-down, "handleKeyCommand", if defined, will be executed for every command.
+   * The first "HandleKeyCommand" that returns true will cause the command to be executed.
+   * "HandleKeyCommand" for subsequent commands will not be executed after the first one returns true.
+   */
+  handleKeyCommand?: HandleKeyCommand;
 }

--- a/src/types/FunctionTypes.ts
+++ b/src/types/FunctionTypes.ts
@@ -3,3 +3,7 @@ import * as React from "react";
 export type GenerateMarkdownPreview = (
   markdown: string
 ) => Promise<React.ReactNode>;
+
+export type HandleKeyCommand = (
+  e: React.KeyboardEvent<HTMLTextAreaElement>
+) => boolean;

--- a/src/util/CommandUtils.ts
+++ b/src/util/CommandUtils.ts
@@ -1,20 +1,22 @@
 import { Command, CommandGroup } from "../types";
 
-// Extracts a map that associate "key commands" (strings) with react-mde Commands.
-// This is important because, when pressing tab, for example, Draft.js issues
-// a "tab" command. We need to associate the key bindings with react-mde commands.
-export function extractCommandMap(
+/**
+ * Returns a flat array of commands that can be activated by the keyboard.
+ * When keydowns happen, these commands 'handleKeyCommand' will be executed, in this order,
+ * and the first that returns true will be executed.
+ */
+export function extractKeyActivatedCommands(
   groups: CommandGroup[]
-): { [key: string]: Command } {
-  const result: { [key: string]: Command } = {};
+): Array<Command> {
+  const result: Array<Command> = [];
   if (!groups || !groups.length) {
     return result;
   }
-  for (let group of groups) {
+  for (const group of groups) {
     if (group.commands && group.commands.length) {
-      for (let command of group.commands) {
-        if (command.keyCommand) {
-          result[command.keyCommand] = command;
+      for (const command of group.commands) {
+        if (command.handleKeyCommand) {
+          result.push(command);
         }
       }
     }


### PR DESCRIPTION
## Breaking changes:
- `className` prop is gone. You must now pass classes using the `classes` object. **This prop has been obsolete for a while**.
Example:
```
          classes={{
            reactMde: "react-mde",
            suggestionsDropdown: "sug-dropdown",
          }}
```
- `textAreaProps` prop is gone. You must now use the `childProps`. **This prop has been obsolete for a while**.
Example:
```
          childProps={{
            textArea: {
              a: 1
            }
          }}
```
- For custom commands, the `keyCommand` field is gone. This was useless and was left there from the Draft.js times.

## New features:
- Commands can now have async `execute` functions. This is to facilitate adding the upload image functionality, since I am planning that to be a long running command, under the hoods.
- Commands now can implement a `handleKeyCommand` handler. This function will be called for every keydown inside the textarea. If this function returns true, the command will be executed.
Example:
```
handleKeyCommand: e => (e.ctrlKey || e.metaKey) && e.key == "b"
```
- There is now a `refs` prop to allow passing refs down to sub-components:
Example:
```
          refs={{
            textarea: React.createRef(),
            preview: React.createRef()
          }}
```