### PR TITLE
Enable keyboard shortcuts even without suggestions

### DIFF
--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -387,7 +387,7 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
           value={value}
           data-testid="text-area"
           onBlur={suggestionsEnabled ? this.handleBlur : undefined}
-          onKeyDown={suggestionsEnabled ? this.handleKeyDown : undefined}
+          onKeyDown={this.handleKeyDown}
           onKeyUp={suggestionsEnabled ? this.handleKeyUp : undefined}
           onKeyPress={suggestionsEnabled ? this.handleKeyPress : undefined}
           {...textAreaProps}


### PR DESCRIPTION
The `handleKeyDown` function handles both keyboard shortcuts and suggestions, but is only called if suggestions are enabled. This change ensures its always called.