### PR TITLE
Opportunity to provide custom initial editor height (optional)

### DIFF
--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -32,6 +32,7 @@ export interface ReactMdeProps {
   generateMarkdownPreview: GenerateMarkdownPreview;
   minEditorHeight: number;
   maxEditorHeight: number;
+  initialEditorHeight?: number;
   minPreviewHeight: number;
   classes?: Classes;
   refs?: Refs;
@@ -111,7 +112,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       this.props.paste
     );
     this.state = {
-      editorHeight: props.minEditorHeight
+      editorHeight: props.initialEditorHeight ?? props.minEditorHeight
     };
   }
 


### PR DESCRIPTION
I'm using "react-mde" and I've faced an issue that editor height is set to the `minEditorHeight`. This disables opportunity to make editor smaller later.
I've made a small change which should solve this problem. 