### PR TITLE
Make sure minHeight is not bigger then maxHeight

### DIFF
--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -111,8 +111,12 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       this.props.l18n,
       this.props.paste
     );
+    const minEditorHeight = Math.min(
+      props.maxEditorHeight,
+      props.minEditorHeight
+    );
     this.state = {
-      editorHeight: props.initialEditorHeight ?? props.minEditorHeight
+      editorHeight: props.initialEditorHeight ?? minEditorHeight
     };
   }
 


### PR DESCRIPTION
Hello!

First of all, thank you for your great project.

I looked for contributing rules but didn't find any. Please let me know if I'm violating any and I can fix.
This small PR adds a guard to assure that `props.minEditorHeight` in not greater than `props.maxEditorHeight`.

The use case is this:

```jsx
<ReactMde maxEditorHeight={100} />
```

Today, the following code renders a 200px height `textarea`

(my) expected result would be a 100px height `textarea`

I understand that today I can do
```jsx
<ReactMde maxEditorHeight={100} minEditorHeight={100} />
```

But that seems a bit unnecessary