### PR TITLE
Implements #208: full screen/page for better documentation authoring

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "useTabs": false,
   "jsxBracketSameLine": false,
   "arrowParens": "avoid",
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "parser": typescript"
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import ReactMde from "../src";
 import * as Showdown from "showdown";
+import { classNames } from "../src/util/ClassNames";
 import { SaveImageHandler, Suggestion } from "../src/types";
 
 export interface AppState {
   value: string;
   tab: "write" | "preview";
+  maximized: boolean;
 }
 
 export class App extends React.Component<{}, AppState> {
@@ -15,7 +17,8 @@ export class App extends React.Component<{}, AppState> {
     super(props);
     this.state = {
       value: "**Hello world!!!**",
-      tab: "write"
+      tab: "write",
+      maximized: false
     };
     this.converter = new Showdown.Converter({
       tables: true,
@@ -31,6 +34,10 @@ export class App extends React.Component<{}, AppState> {
 
   handleTabChange = (tab: "write" | "preview") => {
     this.setState({ tab });
+  };
+
+  handleMaximizedChange = (isMaximized: boolean) => {
+    this.setState({ maximized: isMaximized });
   };
 
   loadSuggestions = async (text: string) => {
@@ -60,9 +67,9 @@ export class App extends React.Component<{}, AppState> {
   };
 
   render() {
-    const save: SaveImageHandler = async function*(data: ArrayBuffer) {
+    const save: SaveImageHandler = async function* (data: ArrayBuffer) {
       // Promise that waits for "time" milliseconds
-      const wait = function(time: number) {
+      const wait = function (time: number) {
         return new Promise((a, r) => {
           setTimeout(() => a(), time);
         });
@@ -83,10 +90,13 @@ export class App extends React.Component<{}, AppState> {
     };
 
     return (
-      <div className="container">
+      <div
+        className={classNames("container", { maximized: this.state.maximized })}
+      >
         <ReactMde
           onChange={this.handleValueChange}
           onTabChange={this.handleTabChange}
+          onMaximizedChange={this.handleMaximizedChange}
           value={this.state.value}
           generateMarkdownPreview={markdown =>
             Promise.resolve(this.converter.makeHtml(markdown))

--- a/demo/client.tsx
+++ b/demo/client.tsx
@@ -7,4 +7,4 @@ import "../src/styles/react-mde-all.scss";
 import "./styles/demo.scss";
 import "./styles/variables.scss";
 
-render(<App />, document.getElementById("#app_container"));
+render(<App />, document.getElementById("app_container"));

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,17 +1,18 @@
 <html>
-
-<head>
+  <head>
     <title>react-mde</title>
-    <meta http-equiv='X-UA-Compatible' content='IE=edge' />
-    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js" integrity="sha384-kW+oWsYx3YpxvjtZjFXqazFpA7UP/MbiY4jvs+RWZo2+N94PFZ36T6TFkc9O3qoB" crossorigin="anonymous"></script>
-</head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script
+      defer
+      src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"
+      integrity="sha384-kW+oWsYx3YpxvjtZjFXqazFpA7UP/MbiY4jvs+RWZo2+N94PFZ36T6TFkc9O3qoB"
+      crossorigin="anonymous"
+    ></script>
+  </head>
 
-<body>
-    <div>
-        <div id="#app_container"></div>
-    </div>
-    <script src='bundle.js'></script>
-</body>
-
+  <body>
+    <div id="app_container"></div>
+    <script src="bundle.js"></script>
+  </body>
 </html>

--- a/demo/styles/demo.scss
+++ b/demo/styles/demo.scss
@@ -1,17 +1,30 @@
-@import 'variables.scss';
+@import "variables.scss";
 
 * {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {
-    font-size: 14px;
-    font-family: sans-serif;
+  font-size: 14px;
+  font-family: sans-serif;
+}
+
+#app_container {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
 }
 
 .container {
-    max-width: 650px;
-    height: 600px;
-    padding: 10px;
-    margin: 0 auto;
+  max-width: 650px;
+  height: 600px;
+  padding: 10px;
+  margin: 0 auto;
+
+  &.maximized {
+    display: flex;
+    max-width: none;
+    height: auto;
+    flex: 1;
+  }
 }

--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -29,6 +29,7 @@ export interface ReactMdeProps {
   onChange: (value: string) => void;
   selectedTab: "write" | "preview";
   onTabChange: (tab: "write" | "preview") => void;
+  onMaximizedChange: (isMaximized: boolean) => void;
   generateMarkdownPreview: GenerateMarkdownPreview;
   minEditorHeight: number;
   maxEditorHeight: number;
@@ -67,6 +68,7 @@ export interface ReactMdeProps {
 
 export interface ReactMdeState {
   editorHeight: number;
+  maximized: boolean;
 }
 
 export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
@@ -116,7 +118,8 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       props.minEditorHeight
     );
     this.state = {
-      editorHeight: props.initialEditorHeight ?? minEditorHeight
+      editorHeight: props.initialEditorHeight ?? minEditorHeight,
+      maximized: false
     };
   }
 
@@ -187,6 +190,13 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
     onTabChange(newTab);
   };
 
+  handleMaximize = () => {
+    const { onMaximizedChange } = this.props;
+    this.setState({ maximized: !this.state.maximized }, () =>
+      onMaximizedChange(this.state.maximized)
+    );
+  };
+
   componentDidMount() {
     document.addEventListener<"mousemove">(
       "mousemove",
@@ -239,6 +249,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
         className={classNames(
           "react-mde",
           "react-mde-tabbed-layout",
+          { "react-mde-maximized": this.state.maximized },
           classes?.reactMde
         )}
       >
@@ -247,6 +258,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
           buttons={toolbarButtons}
           onCommand={this.handleCommand}
           onTabChange={this.handleTabChange}
+          onMaximize={this.handleMaximize}
           tab={selectedTab}
           readOnly={readOnly}
           disablePreview={disablePreview}
@@ -255,7 +267,11 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
           writeButtonProps={finalChildProps.writeButton}
           previewButtonProps={finalChildProps.previewButton}
         />
-        <div className={classNames({ invisible: selectedTab !== "write" })}>
+        <div
+          className={classNames("mde-editor", {
+            invisible: selectedTab !== "write"
+          })}
+        >
           <TextArea
             classes={classes?.textArea}
             suggestionsDropdownClasses={classes?.suggestionsDropdown}
@@ -266,7 +282,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
             readOnly={readOnly}
             textAreaComponent={textAreaComponent}
             textAreaProps={childProps && childProps.textArea}
-            height={this.state.editorHeight}
+            height={this.state.maximized ? undefined : this.state.editorHeight}
             value={value}
             suggestionTriggerCharacters={suggestionTriggerCharacters}
             loadSuggestions={loadSuggestions}
@@ -288,12 +304,14 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
               </span>
             </label>
           )}
-          <div
-            className={classNames("grip", classes?.grip)}
-            onMouseDown={this.handleGripMouseDown}
-          >
-            <GripSvg />
-          </div>
+          {!this.state.maximized ? (
+            <div
+              className={classNames("grip", classes?.grip)}
+              onMouseDown={this.handleGripMouseDown}
+            >
+              <GripSvg />
+            </div>
+          ) : null}
         </div>
         {selectedTab !== "write" && (
           <Preview

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,6 +5,7 @@ import { classNames, ClassValue } from "../util/ClassNames";
 import { ToolbarButtonGroup } from "./ToolbarButtonGroup";
 import { ToolbarButton } from "./ToolbarButton";
 import { ButtonChildProps } from "../child-props";
+import { SvgIcon } from "../icons";
 
 export interface ToolbarButtonData {
   commandName: string;
@@ -18,6 +19,7 @@ export interface ToolbarProps {
   buttons: ToolbarButtonData[][];
   onCommand: (commandName: string) => void;
   onTabChange: (tab: Tab) => void;
+  onMaximize: () => void;
   readOnly: boolean;
   disablePreview: boolean;
   tab: Tab;
@@ -31,6 +33,11 @@ export class Toolbar extends React.Component<ToolbarProps> {
   handleTabChange = (tab: Tab) => {
     const { onTabChange } = this.props;
     onTabChange(tab);
+  };
+
+  handleMaximize = () => {
+    const { onMaximize } = this.props;
+    onMaximize();
   };
 
   render() {
@@ -91,6 +98,13 @@ export class Toolbar extends React.Component<ToolbarProps> {
             })}
           </ToolbarButtonGroup>
         ))}
+        <ul className="mde-header-group-right">
+          <li className="mde-header-item">
+            <button type="button" onClick={() => this.handleMaximize()}>
+              <SvgIcon icon="maximize" />
+            </button>
+          </li>
+        </ul>
       </div>
     );
   }

--- a/src/icons/SvgIcon.tsx
+++ b/src/icons/SvgIcon.tsx
@@ -199,6 +199,30 @@ const boldIcon = (
   </svg>
 );
 
+const maximizeIcon = (
+  <svg
+    className="svg-icon"
+    aria-hidden="true"
+    data-prefix="fas"
+    data-icon="bold"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1000 1000"
+    data-fa-i2svg=""
+  >
+    <g>
+      <path
+        fill="currentColor"
+        d="M885,80c21,0,35,14,35,35v770c0,21-14,35-35,35H115c-21,0-35-14-35-35V115c0-21,14-35,35-35H885 M885,10H115C55.5,10,10,55.5,10,115v770c0,59.5,45.5,105,105,105h770c59.5,0,105-45.5,105-105V115C990,55.5,944.5,10,885,10L885,10z"
+      />
+      <path
+        fill="currentColor"
+        d="M570,185l87.5,87.5L535,395l70,70l122.5-122.5L815,430V185H570z M395,535L272.5,657.5L185,570v245h245l-87.5-87.5L465,605L395,535z"
+      />
+    </g>
+  </svg>
+);
+
 export const SvgIcon: React.FunctionComponent<IconProviderProps> = ({
   icon
 }) => {
@@ -225,6 +249,8 @@ export const SvgIcon: React.FunctionComponent<IconProviderProps> = ({
       return orderedListIcon;
     case "checked-list":
       return checkedListIcon;
+    case "maximize":
+      return maximizeIcon;
     default:
       return null;
   }

--- a/src/styles/react-mde-editor.scss
+++ b/src/styles/react-mde-editor.scss
@@ -1,14 +1,23 @@
 @import "variables.scss";
 
-.mde-textarea-wrapper {
-  position: relative;
+.mde-editor {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 
-  textarea.mde-text {
-    width: 100%;
-    border: 0;
-    padding: $mde-editor-padding;
-    vertical-align: top;
-    resize: none;
-    overflow-y: auto;
+  .mde-textarea-wrapper {
+    display: flex;
+    flex: 1;
+    position: relative;
+
+    textarea.mde-text {
+      display: flex;
+      flex: 1;
+      border: 0;
+      padding: $mde-editor-padding;
+      vertical-align: top;
+      resize: none;
+      overflow-y: auto;
+    }
   }
 }

--- a/src/styles/react-mde-toolbar.scss
+++ b/src/styles/react-mde-toolbar.scss
@@ -23,7 +23,7 @@
         margin-left: 6px;
       }
       &.selected {
-        border: 1px solid $mde-border-color
+        border: 1px solid $mde-border-color;
       }
     }
   }
@@ -34,7 +34,7 @@
     display: inline-block;
     font-size: inherit;
     overflow: visible;
-    vertical-align: -.125em;
+    vertical-align: -0.125em;
   }
 
   ul.mde-header-group {
@@ -115,5 +115,85 @@
       }
     }
   }
-}
 
+  ul.mde-header-group-right {
+    margin: 0;
+    padding: $mde-toolbar-padding;
+    list-style: none;
+    display: flex;
+    flex: 1;
+    flex-direction: row-reverse;
+    flex-wrap: nowrap;
+
+    &.hidden {
+      visibility: hidden;
+    }
+
+    li.mde-header-item {
+      display: inline-block;
+      position: relative;
+      margin: 0 4px;
+      button {
+        text-align: left;
+        cursor: pointer;
+        height: 22px;
+        padding: 4px;
+        margin: 0;
+        border: none;
+        background: none;
+        color: $mde-button-color;
+        @keyframes tooltip-appear {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+        @mixin tooltip-animation {
+          animation-name: tooltip-appear;
+          animation-duration: 0.2s;
+          animation-delay: 0.5s;
+          animation-fill-mode: forwards;
+        }
+        &.tooltipped {
+          &:hover::before {
+            @include tooltip-animation();
+            opacity: 0;
+            position: absolute;
+            z-index: 1000001;
+            width: 0;
+            height: 0;
+            color: rgba(0, 0, 0, 0.8);
+            pointer-events: none;
+            content: "";
+            border: 5px solid transparent;
+            top: -5px;
+            right: 50%;
+            bottom: auto;
+            margin-right: -5px;
+            border-top-color: rgba(0, 0, 0, 0.8);
+          }
+          &:hover::after {
+            @include tooltip-animation();
+            font-size: 11px;
+            opacity: 0;
+            position: absolute;
+            z-index: 1000000;
+            padding: 5px 8px;
+            color: #fff;
+            pointer-events: none;
+            content: attr(aria-label);
+            background: rgba(0, 0, 0, 0.8);
+            border-radius: 3px;
+            right: 50%;
+            bottom: 100%;
+            transform: translateX(50%);
+            margin-bottom: 5px;
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/styles/react-mde.scss
+++ b/src/styles/react-mde.scss
@@ -28,7 +28,6 @@ $grip-height: 10px;
   }
 
   .image-tip {
-
     display: flex !important;
     padding: 7px 10px;
     margin: 0;
@@ -41,7 +40,7 @@ $grip-height: 10px;
 
     .image-input {
       min-height: 0;
-      opacity: .01;
+      opacity: 0.01;
       width: 100% !important;
       position: absolute;
       top: 0;
@@ -49,6 +48,11 @@ $grip-height: 10px;
       padding: 5px;
       cursor: pointer;
     }
-
   }
+}
+
+.react-mde-maximized {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }


### PR DESCRIPTION
Adds a "full screen" button to allow customizing the editor to make it full screen; adds an `onMaximizeChange` event to allow the libray user code to modify the container, etc.

![ScreenFlow](https://user-images.githubusercontent.com/517228/90346628-0e6f8480-e001-11ea-847c-ebbb3ab07e2b.gif)
