### PR TITLE
Tweaks: add text to l18n; adjust css styles for "image-tip"

### DIFF
--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -283,9 +283,7 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
                 multiple
                 onChange={this.handleImageSelection}
               />
-              <span>
-                Attach files by dragging & dropping, selecting or pasting them.
-              </span>
+              <span>{l18n.pasteDropSelect}</span>
             </label>
           )}
           <div

--- a/src/l18n/react-mde.en.ts
+++ b/src/l18n/react-mde.en.ts
@@ -3,5 +3,6 @@ import { L18n } from "..";
 export const enL18n: L18n = {
   write: "Write",
   preview: "Preview",
-  uploadingImage: "Uploading image..."
+  uploadingImage: "Uploading image...",
+  pasteDropSelect: "Attach files by dragging & dropping, selecting or pasting them."
 };

--- a/src/l18n/react-mde.zh-CN.ts
+++ b/src/l18n/react-mde.zh-CN.ts
@@ -3,5 +3,6 @@ import { L18n } from "..";
 export const zhL18n: L18n = {
   write: "编辑",
   preview: "预览",
-  uploadingImage: "正在上传图片..."
+  uploadingImage: "正在上传图片...",
+  pasteDropSelect: "通过拖放，选择和粘贴来附加文件。"
 };

--- a/src/styles/react-mde.scss
+++ b/src/styles/react-mde.scss
@@ -28,7 +28,7 @@ $grip-height: 10px;
   }
 
   .image-tip {
-
+    user-select: none;
     display: flex !important;
     padding: 7px 10px;
     margin: 0;

--- a/src/types/L18n.ts
+++ b/src/types/L18n.ts
@@ -7,4 +7,5 @@ export interface L18n {
    * Text used to indicate that an image is being uploaded
    */
   uploadingImage: string;
+  pasteDropSelect: string;
 }


### PR DESCRIPTION
Minor tweaks

@andrerpena on the resizing grip, I've looked on how Github does that: it seems it's only simple css (`resize: vertical`); so I think all the `minEditorHeight`,`maxEditorHeight` would be obsolete when going for it, and just add `min-height`,`max-height` css; what do u think?

By obsolete, I mean all the _grip dragging event/logic/state_ involved right now.