### PR TITLE
Changes in loadSuggestions function signature

### DIFF
--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -43,7 +43,7 @@ export interface ReactMdeProps {
   readOnly?: boolean;
   disablePreview?: boolean;
   suggestionTriggerCharacters?: string[];
-  loadSuggestions?: (text: string) => Promise<Suggestion[]>;
+  loadSuggestions?: (text: string, triggeredBy: string) => Promise<Suggestion[]>;
   childProps?: ChildProps;
   paste?: PasteOptions;
   l18n?: L18n;


### PR DESCRIPTION
This should fix errors/warning from typescript, as `triggeredBy` parameter is missing in `loadSuggestions` function signature, but in fact is passed