### PR TITLE
Handle blur/keyUp/keyPress event even if suggestion is not enabled

### DIFF
--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -400,8 +400,8 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
             this.handleOnChange(event);
           }}
           onBlur={event => {
+            textAreaProps?.onBlur?.(event);
             if (suggestionsEnabled) {
-              textAreaProps?.onBlur?.(event);
               this.handleBlur();
             }
           }}
@@ -410,14 +410,14 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
             this.handleKeyDown(event);
           }}
           onKeyUp={event => {
+            textAreaProps?.onKeyUp?.(event);
             if (suggestionsEnabled) {
-              textAreaProps?.onKeyUp?.(event);
               this.handleKeyUp(event);
             }
           }}
           onKeyPress={event => {
+            textAreaProps?.onKeyPress?.(event);
             if (suggestionsEnabled) {
-              textAreaProps?.onKeyPress?.(event);
               this.handleKeyPress(event);
             }
           }}


### PR DESCRIPTION
In the current implementation, only when `suggestionsEnabled` is `true` the `onBlur`, `onKeyUp`, `onKeyPress` functions passed  as props will be invoked. 

```jsx
<ReactMde
  value={value}
  onChange={setValue}
  selectedTab={selectedTab}
  onTabChange={setSelectedTab}
  generateMarkdownPreview={(markdown) =>
    Promise.resolve(converter.makeHtml(markdown))
  }
  childProps={{
    textArea: {
      // only onFocus will be fired in the current implementation
      onFocus: () => console.log("Focus"),
      onBlur: () => console.log("Blur"),
      onKeyUp: () => console.log("KeyUp"),
    },
  }}
/>
```

By moving the lines outside of the `if` block, the editor will fire those event handlers regardless of the value of `suggestionsEnabled`.
