### PR TITLE
remove image markdown when upload image fail

### DIFF
--- a/src/commands/default-commands/save-image-command.tsx
+++ b/src/commands/default-commands/save-image-command.tsx
@@ -78,8 +78,7 @@ export const saveImageCommand: Command = {
           end: initialState.selection.start + placeHolder.length
         });
 
-        const realImageMarkdown = `${breaksBefore}![image](${imageUrl})`;
-
+        const realImageMarkdown = imageUrl ? `${breaksBefore}![image](${imageUrl})` : "";
         const selectionDelta = realImageMarkdown.length - placeHolder.length;
 
         textApi.replaceSelection(realImageMarkdown);


### PR DESCRIPTION
When the upload image failed in Github, the markdown is removed.

**root cause**
There is no handling when upload image fail. We use the same logic as upload image pass.

**solution**
Apply solution the same way as Github handles, which is to remove the markdown image.

**before**
https://www.awesomescreenshot.com/video/1924220?key=896afa60d3db683b8f1dcffdabbefbd1

**after**
https://www.awesomescreenshot.com/video/1924236?key=0db887ced737db9a7a6b2b9635290270