### PR TITLE
fix upload multiple files

### DIFF
--- a/src/commands/default-commands/save-image-command.tsx
+++ b/src/commands/default-commands/save-image-command.tsx
@@ -42,18 +42,19 @@ export const saveImageCommand: Command = {
     const items = isPasteEvent(context)
       ? dataTransferToArray((event as React.ClipboardEvent).clipboardData.items)
       : isDragEvent(context)
-      ? dataTransferToArray((event as React.DragEvent).dataTransfer.items)
-      : fileListToArray(
+        ? dataTransferToArray((event as React.DragEvent).dataTransfer.items)
+        : fileListToArray(
           (event as React.ChangeEvent<HTMLInputElement>).target.files
         );
 
     for (const index in items) {
+      const initialState = textApi.getState();
       const breaksBeforeCount = getBreaksNeededForEmptyLineBefore(
         initialState.text,
         initialState.selection.start
       );
-      const breaksBefore = Array(breaksBeforeCount + 1).join("\n");
 
+      const breaksBefore = Array(breaksBeforeCount + 1).join("\n");
       const placeHolder = `${breaksBefore}![${l18n.uploadingImage}]()`;
 
       textApi.replaceSelection(placeHolder);


### PR DESCRIPTION
**root cause**
When the first file is uploaded successfully, the text in mde will be changed. Then for the second file, `initialState.text` does not return the updated text. This made the logic to use wrong indexes.

**solution**
Get the latest state for each upload.

**before**
https://www.awesomescreenshot.com/video/1924292?key=8000ff6cf74c3522b31e5f9034a4d4bd

**after**
https://www.awesomescreenshot.com/video/1924303?key=6c87c9432d242e9d94362d2a8afff4ff