### PR TITLE
remove absolutely useless useCallback

### DIFF
--- a/src/components/SuggestionsDropdown.tsx
+++ b/src/components/SuggestionsDropdown.tsx
@@ -24,23 +24,20 @@ export const SuggestionsDropdown: React.FunctionComponent<SuggestionsDropdownPro
   focusIndex,
   textAreaRef
 }) => {
-  const handleSuggestionClick = useCallback(
+  const handleSuggestionClick =
     (event: React.MouseEvent) => {
       event.preventDefault();
       const index = parseInt(
         event.currentTarget.attributes["data-index"].value
       );
       onSuggestionSelected(index);
-    },
-    [suggestions]
-  );
+    };
 
   // onMouseDown should be cancelled because onClick will handle it propertly. This way, the textarea does not lose
   // focus
-  const handleMouseDown = useCallback(
-    (event: React.MouseEvent) => event.preventDefault(),
-    []
-  );
+  const handleMouseDown =
+    (event: React.MouseEvent) => event.preventDefault();
+  
   return (
     <ul
       className={classNames("mde-suggestions", classes)}


### PR DESCRIPTION
Remove the useless `useCallback` - it doesn't have any performance benefits (it is probably even worse that without it) and has the added drawback of not allowing to use the suggestions in Class components