### PR TITLE
Allow customizing paste command options

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -47,6 +47,15 @@ export interface PasteOptions {
    * Command to execute on paste command
    */
   command?: string;
+  /**
+   * The accept attribute specifies a filter for what file types the user can pick from the file input dialog box.
+   */
+  accept?: string;
+  /**
+   * When present, it specifies that the user is allowed to enter more than one value in the file input dialog box.
+   * By default is set to true
+   */
+  multiple?: boolean;
 }
 
 export type SaveImageHandler = (

--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -243,8 +243,8 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
               <input
                 className={classNames("image-input")}
                 type="file"
-                accept="image/*"
-                multiple
+                accept={this.props.paste.accept || "image/*"}
+                multiple={this.props.paste.multiple || true}
                 onChange={this.handleImageSelection}
               />
               <span>{l18n.pasteDropSelect}</span>


### PR DESCRIPTION
When using react-mde we want to upload different types of files (not only images) and use a custom command on paste.

Adding two new optional parameters to customize the accept and multiple properties of the ``input`` html element.