### PR TITLE
Fix new customized paste options

### DIFF
--- a/src/commands/command-orchestrator.ts
+++ b/src/commands/command-orchestrator.ts
@@ -143,7 +143,7 @@ export class CommandOrchestrator {
       return this.executeCommand(
         this.pasteOptions.command || getDefaultSaveImageCommandName(),
         {
-          saveImage: this.pasteOptions.saveImage,
+          pasteOptions: this.pasteOptions,
           event: event
         } as PasteCommandContext
       );
@@ -158,7 +158,7 @@ export class CommandOrchestrator {
       return this.executeCommand(
         this.pasteOptions.command || getDefaultSaveImageCommandName(),
         {
-          saveImage: this.pasteOptions.saveImage,
+          pasteOptions: this.pasteOptions,
           event: event
         } as PasteCommandContext
       );
@@ -173,7 +173,7 @@ export class CommandOrchestrator {
       return this.executeCommand(
         this.pasteOptions.command || getDefaultSaveImageCommandName(),
         {
-          saveImage: this.pasteOptions.saveImage,
+          pasteOptions: this.pasteOptions,
           event: event
         } as PasteCommandContext
       );

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -31,7 +31,7 @@ export interface CommandContext {
 export interface PasteCommandContext extends CommandContext {
   type: "paste";
   event: React.ClipboardEvent | React.DragEvent | React.ChangeEvent;
-  saveImage: SaveImageHandler;
+  pasteOptions: PasteOptions;
 }
 
 export type ToolbarCommands = string[][];

--- a/src/components/ReactMde.tsx
+++ b/src/components/ReactMde.tsx
@@ -73,6 +73,14 @@ export interface ReactMdeState {
   editorHeight: number;
 }
 
+const pasteOptionDefaults: Required<Omit<
+  PasteOptions,
+  "saveImage" | "command"
+>> = {
+  accept: "image/*",
+  multiple: false
+};
+
 export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
   /**
    * "finalRefs" is a clone of "props.refs" except that undefined refs are set to default values
@@ -110,6 +118,8 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
       this.finalRefs.textarea,
       this.props.l18n,
       this.props.paste
+        ? { ...pasteOptionDefaults, ...this.props.paste }
+        : undefined
     );
     const minEditorHeight = Math.min(
       props.maxEditorHeight,
@@ -243,8 +253,10 @@ export class ReactMde extends React.Component<ReactMdeProps, ReactMdeState> {
               <input
                 className={classNames("image-input")}
                 type="file"
-                accept={this.props.paste.accept || "image/*"}
-                multiple={this.props.paste.multiple || true}
+                accept={this.props.paste.accept ?? pasteOptionDefaults.accept}
+                multiple={
+                  this.props.paste.multiple ?? pasteOptionDefaults.multiple
+                }
                 onChange={this.handleImageSelection}
               />
               <span>{l18n.pasteDropSelect}</span>


### PR DESCRIPTION
The PR #310  allows new customized paste options, which is a great addition

However, there are some issues.

1. If `multiple` is passed **false** to the ReactMde component, `this.props.paste.multiple || true` evaluates into true anyway.
2. `active` and `multiple` only affects file input component, it doesn't help with drag and drop/paste events.

This PR fixes those issues.