### PR TITLE
Provide file metadata for image/file upload.

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -60,7 +60,7 @@ export class App extends React.Component<{}, AppState> {
   };
 
   render() {
-    const save: SaveImageHandler = async function*(data: ArrayBuffer) {
+    const save: SaveImageHandler = async function*(data: ArrayBuffer, file: Blob) {
       // Promise that waits for "time" milliseconds
       const wait = function(time: number) {
         return new Promise((a, r) => {

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -59,5 +59,6 @@ export interface PasteOptions {
 }
 
 export type SaveImageHandler = (
-  data: ArrayBuffer
+  data: ArrayBuffer,
+  file: Blob
 ) => AsyncGenerator<string, boolean>;

--- a/src/commands/default-commands/save-image-command.tsx
+++ b/src/commands/default-commands/save-image-command.tsx
@@ -61,7 +61,7 @@ export const saveImageCommand: Command = {
 
       const blob = items[index];
       const blobContents = await readFileAsync(blob);
-      const savingImage = saveImage(blobContents);
+      const savingImage = saveImage(blobContents, blob);
       const imageUrl = (await savingImage.next()).value;
 
       const newState = textApi.getState();


### PR DESCRIPTION
Something I can't understand is why the save image command passes an `ArrayBuffer` to the callback. The issue is that `ArrayBuffer` doesn't have the file metadata such as mime type, filename, and extension. I need this metadata in order to handle files in my server response. Furthermore, I'm not aware of any advantages `ArrayBuffer` provides for file uploads. 
Both `XMLHttpRequest` and `fetch` apis natively support `Blob`. So I think ideally we wouldn't bother with `ArrayBuffer`.

Looking around it looks like this is confusing other people as well.
https://github.com/andrerpena/react-mde/issues/290
https://github.com/andrerpena/react-mde/pull/268#issuecomment-707563996

For the change to avoid any BC breaks I appended the `File` instance to the saveImage callback arguments. Later on I would consider removing `ArrayBuffer`.

Let me know if this makes sense, or if I'm missing anything.